### PR TITLE
reverted token split for Empire

### DIFF
--- a/bribe-data-16.json
+++ b/bribe-data-16.json
@@ -1,5 +1,5 @@
 {
-  "version": "16.6.2",
+  "version": "16.6.3",
   "snapshot": "0xbc5785e1323c70986d77d33ab734c1c18f122c2a6082f84fbc437c549d8b84ad",
   "description": "Farming Incentive Gauge Vote (round 16)",
   "round": 16,
@@ -8,11 +8,6 @@
       "token": "BEETS",
       "tokenaddress": "0xf24bcf4d1e507740041c9cfd2dddb29585adce1e",
       "coingeckoid": "beethoven-x"
-    },
-    {
-      "token": "GEM",
-      "tokenaddress": "0x68efc4716507709691d5e7ad9906a44fabcdb1ca",
-      "coingeckoid": "mine-empire"
     }
   ],
   "bribedata": [
@@ -45,8 +40,7 @@
       "rewarddescription": "This round we are keeping the 1500 USDC and throwing an additional 11 GEMs to our bribe for a total value of $2478.",
       "assumption": "",
       "fixedreward": [
-        { "token": "USDC", "amount": 1500, "isfixed": true },
-        { "token": "GEM", "amount": 11, "isfixed": false }
+        { "token": "USDC", "amount": 2478, "isfixed": true }
       ],
       "percentreward": [],
       "percentagethreshold": 0


### PR DESCRIPTION
GEM Token price does not load. 
Errormessage in console:

index.ts:261 Uncaught (in promise) Error: missing revert data in call exception; Transaction reverted without a reason string [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (data="0x", transaction={"to":"0x33365E1B22BbeF5766419e19f77c15fD3E0a8Ae5","data":"0x47c536af00000000000000000000000068efc4716507709691d5e7ad9906a44fabcdb1ca","accessList":null}, error={"reason":"processing response error","code":"SERVER_ERROR","body":"{\"jsonrpc\":\"2.0\",\"id\":45,\"error\":{\"code\":-32000,\"message\":\"execution reverted\"}}","error":{"code":-32000},"requestBody":"{\"method\":\"eth_call\",\"params\":[{\"to\":\"0x33365e1b22bbef5766419e19f77c15fd3e0a8ae5\",\"data\":\"0x47c536af00000000000000000000000068efc4716507709691d5e7ad9906a44fabcdb1ca\"},\"latest\"],\"id\":45,\"jsonrpc\":\"2.0\"}","requestMethod":"POST","url":"https://rpc.ftm.tools"}, code=CALL_EXCEPTION, version=providers/5.6.8)
    at e.value (index.ts:261:28)
    at e.value (index.ts:273:20)
    at aa (json-rpc-provider.ts:66:16)
    at r.<anonymous> (json-rpc-provider.ts:603:20)
    at f (regeneratorRuntime.js:86:17)
    at Generator._invoke (regeneratorRuntime.js:66:24)
    at Generator.throw (regeneratorRuntime.js:117:21)
    at s (base-provider.ts:702:35)